### PR TITLE
fix: only set placeholder viewcontainer ref if there is non set

### DIFF
--- a/src/placeholder/placeholder.service.ts
+++ b/src/placeholder/placeholder.service.ts
@@ -25,8 +25,10 @@ export class PlaceholderService {
 	registerViewContainerRef(vcRef: ViewContainerRef, id?: any): void {
 		if (id) {
 			this.viewContainerMap.set(id, vcRef);
-		} else {
+		} else if (this.viewContainerRef === null) {
 			this.viewContainerRef = vcRef;
+		} else {
+			console.error("View container has already been defined.");
 		}
 	}
 


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#

{{short description}}

#### Changelog

**New**

* {{new thing}}

**Changed**

* {{change thing}}

**Removed**

* {{removed thing}}


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the component registration process to prevent duplicate assignments and provide clear feedback when an attempt is made to register an already defined container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->